### PR TITLE
File extension with multiple dots

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -127,10 +127,15 @@ module.exports = {
      * @return {boolean}
      */
     isReqFileExtension(file, fileExtensions) {
-        let ext = pth.extname(file);
-        return !fileExtensions.length ||
-            (fileExtensions.length === 1 && !fileExtensions[0]) ||
-            fileExtensions.indexOf(ext) !== -1;
+        let result = !fileExtensions.length || false;
+
+        fileExtensions.forEach(function(ext) {
+            if (!ext || ext === file.slice(ext.length * -1)) {
+                result = true;
+            }
+        });
+
+        return result;
     },
     /**
      * Is excluded file?

--- a/test/test.utils.js
+++ b/test/test.utils.js
@@ -39,7 +39,10 @@ describe('Utils', function() {
     });
 
     it('isReqFileExtension', function() {
+        assert.ok(utils.isReqFileExtension('example.js', []));
+        assert.ok(utils.isReqFileExtension('example.js', ['']));
         assert.ok(utils.isReqFileExtension('example.js', ['.js']));
+        assert.ok(utils.isReqFileExtension('example.ru.js', ['.ru.js']));
         assert.notOk(utils.isReqFileExtension('example.js', ['.css']));
     });
 


### PR DESCRIPTION
Метод `pth.extname(file)` не позволял фильтровать файлы по расширению с несколькими точками, например `.ru.md`.