### PR TITLE
Fixed incorrect term in README.md ("celebrate")

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ This is useful in cases where the service is transmitted to the input of a list 
 Highlight repetitions of words, consecutive. For example, `I flew to to to Cyprus`.
 
 #### `--flag-latin`
-Celebrate words, written in Latin, as erroneous.
+Flag words, written in Latin, as erroneous.
 
 #### `--ignore-tags <tags>`
 Ignore HTML tags.<br/>


### PR DESCRIPTION
The verb had been used was incorrect. We do not say "to celebrate words" in English.